### PR TITLE
show-hide all cards button

### DIFF
--- a/js/add_new.js
+++ b/js/add_new.js
@@ -102,6 +102,9 @@ function deleteQuestionHandler() {
   } else {
     resetFormValues();
   }
+  if(showCards) {
+    showAllCards();
+  }
 }
 
 //function for rendering card for all questions from allQuestion array

--- a/js/add_new.js
+++ b/js/add_new.js
@@ -9,6 +9,7 @@ let showAllCardsButtonEl = document.getElementById('show-all-cards');
 let allCardsWrapperEl = document.getElementById('all-cards-wrapper');
 let questionFound;
 let questionFoundIndex;
+let showCards = false;
 
 // ***HELPER FUNCTIONS***
 //function for filling selectQuestion dropdown with values from allQuestions array
@@ -63,6 +64,7 @@ function selectQuestionHandler() {
 
 //function for adding new question or editing existing
 function submitQuestionHandler(e) {
+  e.preventDefault();
   //get the form values
   let dropdown = selectQuestionEl.value;
   let question = removeEnter(e.target.question.value);
@@ -84,6 +86,9 @@ function submitQuestionHandler(e) {
       resetFormValues();
       populateForm();
     }
+  }
+  if(showCards) {
+    showAllCards();
   }
 }
 
@@ -112,7 +117,21 @@ function showAllCards() {
     let flipCardBackEl = render('div', flipCardInnerEl, false, 'flip-card-back post-it');
     render('p', flipCardBackEl, allQuestions[i].answer);
   }
-  showAllCardsButtonEl.textContent = 'REFRESH CARDS';
+  showCards = true;
+  showAllCardsButtonEl.textContent = 'HIDE CARDS';
+  showAllCardsButtonEl.removeEventListener('click', showAllCards);
+  showAllCardsButtonEl.addEventListener('click', hideCards);
+}
+
+//function for hiding all cards
+function hideCards() {
+  while (allCardsWrapperEl.firstChild) {
+    allCardsWrapperEl.removeChild(allCardsWrapperEl.firstChild);
+  }
+  showCards = false;
+  showAllCardsButtonEl.textContent = 'SHOW ALL CARDS';
+  showAllCardsButtonEl.removeEventListener('click', hideCards);
+  showAllCardsButtonEl.addEventListener('click', showAllCards);
 }
 
 // ***EVENT LISTENERS***


### PR DESCRIPTION
Instead of a Refresh Cards button: on submit of a new or edited card, if Show All Cards was clicked already, then automatically refresh cards instead of the cards just disappearing on submit

Once all cards are shown the button textContent and functionality is changed to 'HIDE CARDS'